### PR TITLE
Handle BOM on utf8 files causing JSON Parse errors

### DIFF
--- a/src/utils/json/index.js
+++ b/src/utils/json/index.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const _ = require('lodash')
 const JsonUtils = require('./jsonUtils.js')
+const TextDecoder = require('node:util');
 
 
 module.exports = class JsonVarSub {
@@ -12,7 +13,7 @@ module.exports = class JsonVarSub {
 
     substitute(filePath, vars, delimiter, outputFile, writeToFile){
         let rawData = fs.readFileSync(filePath);
-        let jsonObject = JSON.parse(rawData);
+        let jsonObject = JSON.parse(new TextDecoder('utf-8', { ignoreBOM: false}).decode(rawData));
         let jUtils = new JsonUtils()
         let modifiedJson = jsonObject;
         let variables = JSON.parse(vars)

--- a/src/utils/json/index.js
+++ b/src/utils/json/index.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const _ = require('lodash')
 const JsonUtils = require('./jsonUtils.js')
-const TextDecoder = require('node:util');
+const { TextDecoder } = require('node:util');
 
 
 module.exports = class JsonVarSub {


### PR DESCRIPTION
Using the TextDecoder solves the problem where an appsettings file had BOM on the front and was breaking the JSON Parsing