### PR TITLE
Fix issue where variable at top level wasn't being found

### DIFF
--- a/src/utils/json/jsonUtils.js
+++ b/src/utils/json/jsonUtils.js
@@ -24,10 +24,15 @@ module.exports = class JsonUtils {
             if(typeof jsonObject[key] === "object") {                     
                 self.printObjectReplace(jsonObject[key], self._createKeyName(keyName, key, delimiter), theKey, keyValue, delimiter);
             } else {                                              
-                if(theKey == `${keyName}${delimiter}${key}`) {
-                    jsonObject[key] = keyValue;
+                if(keyName == '') {
+                    if(theKey == `${key}`) {
+                        jsonObject[key] = keyValue;
+                    }
+                } else {      
+                    if(theKey == `${keyName}${delimiter}${key}`) {
+                        jsonObject[key] = keyValue;
+                    }
                 }
-
             }
         }); 
         return jsonObject;       


### PR DESCRIPTION
Needed to handle the situation where keyname was empty (like when printObjectReplace is first called) and it wasn't finding a variable defined at the top level.

{
"sample_id":"placeholder"
}

wasn't being found (because it was looking for .sample_id as the key instead of just sample_id